### PR TITLE
Better sticky on tablet

### DIFF
--- a/jquery.sticky-kit.coffee
+++ b/jquery.sticky-kit.coffee
@@ -173,6 +173,7 @@ $.fn.stick_in_parent = (opts={}) ->
           elm.insertAfter(spacer).removeClass sticky_class
           spacer.remove()
 
+      win.on "touchmove", tick
       win.on "scroll", tick
       win.on "resize", recalc_and_tick
       $(document.body).on "sticky_kit:recalc", recalc_and_tick

--- a/jquery.sticky-kit.js
+++ b/jquery.sticky-kit.js
@@ -177,6 +177,7 @@
           return spacer.remove();
         }
       };
+      win.on("touchmove", tick);
       win.on("scroll", tick);
       win.on("resize", recalc_and_tick);
       $(document.body).on("sticky_kit:recalc", recalc_and_tick);


### PR DESCRIPTION
Hello,

On tablet the scroll event is not fired continuously like it is on desktop. It is fired _only_ when the scroll actually ends.

The resulting behaviour is that the element does not reposition immediately, but just at the end of the scroll.
For more details see:
[1] http://tjvantoll.com/2012/08/19/onscroll-event-issues-on-mobile-browsers/
[2] http://developer.apple.com/safari/library/documentation/appleapplications/reference/SafariWebContent/HandlingEvents/HandlingEvents.html

In order to mitigate this issue we can use the _touchmove_ event that is triggered continuously during the scroll (as suggested in [2]). 
The problem still remains unsolved for the _momentum_ move. In this scenario the sticky element will not update until the scroll momentum ends.

Any idea on how to solve this issue?
Cheers
