### PR TITLE
Bottomed recalc bug

### DIFF
--- a/jquery.sticky-kit.coffee
+++ b/jquery.sticky-kit.coffee
@@ -22,6 +22,7 @@ $.fn.stick_in_parent = (opts={}) ->
       throw "failed to find stick parent" unless parent.length
 
       fixed = false
+      bottomed = false
       spacer = $("<div />")
 
       recalc = ->
@@ -63,7 +64,6 @@ $.fn.stick_in_parent = (opts={}) ->
       recalc()
       return if height == parent_height
 
-      bottomed = false
       last_pos = undefined
       offset = offset_top
 


### PR DESCRIPTION
If a `recalc` is triggered on a `bottomed` element, we need to restore the `bottomed` specific attributes and variables too.
