### PR TITLE
Pull from window, if @jQuery doesn't resolve

### DIFF
--- a/jquery.sticky-kit.coffee
+++ b/jquery.sticky-kit.coffee
@@ -2,7 +2,7 @@
 @license Sticky-kit v1.0.4 | WTFPL | Leaf Corcoran 2014 | http://leafo.net
 ###
 
-$ = @jQuery
+$ = @jQuery or window.jQuery
 
 win = $ window
 $.fn.stick_in_parent = (opts={}) ->


### PR DESCRIPTION
In "plain" Js, `this` resolves to the window and pulls jQuery from there. That's fine. But when using it with amd/commonjs module loading, `this` may not necessarily equal the window.

This PR changes it, to pull from `window.jQuery` if `this.jQuery` is not defined.
