### PR TITLE
Spacer div height must be the same as container

### DIFF
--- a/jquery.sticky-kit.js
+++ b/jquery.sticky-kit.js
@@ -64,7 +64,7 @@
         el_float = elm.css("float");
         spacer.css({
           width: elm.outerWidth(true),
-          height: height,
+          height: parent_height,
           display: elm.css("display"),
           "vertical-align": elm.css("vertical-align"),
           "float": el_float


### PR DESCRIPTION
The div created to stick the element must have the same height of the parent element, at least when the parent element is diferent than the real parent (defined in options)
