### PR TITLE
When calculating pixel width of divs with percentage width, use a method that doesn't round up

### DIFF
--- a/jquery.sticky-kit.coffee
+++ b/jquery.sticky-kit.coffee
@@ -73,7 +73,7 @@ $.fn.stick_in_parent = (opts={}) ->
 
         el_float = elm.css "float"
         spacer.css({
-          width: elm.outerWidth true
+          width: if elm[0].getBoundingClientRect().width then elm[0].getBoundingClientRect().width else elm.outerWidth true
           height: height
           display: elm.css "display"
           "vertical-align": elm.css "vertical-align"
@@ -159,7 +159,7 @@ $.fn.stick_in_parent = (opts={}) ->
             }
 
             css.width = if elm.css("box-sizing") == "border-box"
-              elm.outerWidth() + "px"
+              if elm[0].getBoundingClientRect().width then elm[0].getBoundingClientRect().width + "px" else elm.outerWidth() + "px"
             else
               elm.width() + "px"
 


### PR DESCRIPTION
In supported browsers, getting the element's width from the [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) function yields a pixel value that is not rounded up after converting an element's percentage width to pixels.

As most grid systems make use of percentage widths, this will solve the issue where sticky element widths are 1 pixel greater than they should be (due to rounding) and break their float as a result.

Where the `width` parameter of the object returned by `getBoundingClientRect()` does not exist, fall back to the current implementation `elm.outerWidth()`

Demonstration of the issue by @eusonic at leafo/sticky-kit#42
