### PR TITLE
Update last_scroll_height after the element was made sticky.

### DIFF
--- a/jquery.sticky-kit.js
+++ b/jquery.sticky-kit.js
@@ -197,6 +197,7 @@
                 spacer.append(elm);
               }
             }
+            last_scroll_height = doc.height();
             elm.trigger("sticky_kit:stick");
           }
         }


### PR DESCRIPTION
If the height of the element changes when it's made sticky it will cause the last_scroll_height !== doc.height() check fail and recalc() will be firing on every tick().

If last_scroll_height is updated right after the element is made sticky and the css class is attached to it, everything works as it should.
