### PR TITLE
Update "main" path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sticky-kit",
   "version": "1.1.3",
   "description": "A jQuery plugin for creating smart sticky elements",
-  "main": "sticky-kit.js",
+  "main": "dist/sticky-kit.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The current "main" path is broken since there’s no `sticky-kit.js` file in the root directory

For #131 