### PR TITLE
fixed typo.

### DIFF
--- a/sticky-kit.coffee
+++ b/sticky-kit.coffee
@@ -182,7 +182,7 @@ $.fn.stick_in_parent = (opts={}) ->
             fixed = true
             css = {
               position: "fixed"
-              top: offset
+              top: offset + "px"
             }
 
             css.width = if elm.css("box-sizing") == "border-box"


### PR DESCRIPTION
This fixes the following issue - when we land on in the middle of the page(a long page) the top is applied without 'px' so it never gets applied.