### PR TITLE
Fix Ugly Jump #238 

### DIFF
--- a/sticky-kit.coffee
+++ b/sticky-kit.coffee
@@ -221,7 +221,7 @@ $.fn.stick_in_parent = (opts={}) ->
             elm.css({
               position: "absolute"
               bottom: padding_bottom
-              top: "auto"
+              top: "calc(100% - " + offset_top + "px)"
             }).trigger("sticky_kit:bottom")
 
       recalc_and_tick = ->


### PR DESCRIPTION
Not sure why top is set to auto. Originally child jumps to top of container without taking in to account offset_top option. This PR fixes the issue (tested).