### PR TITLE
Fix. Element is not moving, when it gets free space to move.

### DIFF
--- a/sticky-kit.coffee
+++ b/sticky-kit.coffee
@@ -109,7 +109,6 @@ $.fn.stick_in_parent = (opts={}) ->
           tick()
 
       recalc()
-      return if height == parent_height
 
       last_pos = undefined
       offset = offset_top


### PR DESCRIPTION
When StickyKit was initialized for element at a moment, where parent's
height was equal to element's height, following issues occurs:
1. When element gets free space (e.g. by page recomposition), it will
not move, because event listeners was not attached;
2. Triggering 'sticky_kit:detach' has no effect.